### PR TITLE
Fix docker for everyone

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git
+node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .git
+*Dockerfile*
+*docker-compose*
 node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Get latest node
 FROM node:8
 
-# install dependencies first, in a different location for easier app bind mounting for local development
+# install dependencies first, in a different location for easier app bind mounting for local development.
+# Note: that means if you try to put it in /app, it will fail...
 # due to default /opt permissions we have to create the dir with root and change perms
-RUN mkdir -p /opt/node_app/app && chown node:node /opt/node_app
+RUN mkdir -p /opt/node_app/app && chown -R node:node /opt/node_app
 WORKDIR /opt/node_app
 
 # the official node image provides an unprivileged user as a security best practice

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ FROM node:8
 # npm install package.json FRESH from a temporary directory
 # to avoid shared volume's node_module's interfering
 COPY package.json /tmp/package.json
-RUN cd /tmp && npm install
+RUN cd /tmp && npm install && cd -
 
-# Make a working directory.
-RUN mkdir -p /usr/src/app && cp -a /tmp/node_modules /usr/src/app
-COPY . /usr/src/app
+# Make a working directory and copy node modules there
+RUN mkdir -p /usr/src/app && cp -a /tmp/node_modules /usr/src/app/
 
 # change our working directory to the one we just built.
 WORKDIR /usr/src/app
+COPY . /usr/src/app
 
 # Expose 3000 for access to our node server
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-
-# Get latest node, make a working directory.
+# Get latest node
 FROM node:8
-RUN mkdir -p /usr/src/app
+
+# npm install package.json FRESH from a temporary directory
+# to avoid shared volume's node_module's interfering
+COPY package.json /tmp/package.json
+RUN cd /tmp && npm install
+
+# Make a working directory.
+RUN mkdir -p /usr/src/app && cp -a /tmp/node_modules /usr/src/app
 COPY . /usr/src/app
 
 # change our working directory to the one we just built.
 WORKDIR /usr/src/app
-RUN npm install
-
-# Stupid we need to do this but there's some issue with bcrypt
-RUN npm rebuild bcrypt --update-binary
 
 # Expose 3000 for access to our node server
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,24 @@
 # Get latest node
 FROM node:8
 
-# npm install package.json FRESH from a temporary directory
-# to avoid shared volume's node_module's interfering
-COPY package.json /tmp/package.json
-RUN cd /tmp && npm install && cd -
+# install dependencies first, in a different location for easier app bind mounting for local development
+# due to default /opt permissions we have to create the dir with root and change perms
+RUN mkdir -p /opt/node_app/app && chown node:node /opt/node_app
+WORKDIR /opt/node_app
 
-# Make a working directory and copy node modules there
-RUN mkdir -p /usr/src/app && cp -a /tmp/node_modules /usr/src/app/
+# the official node image provides an unprivileged user as a security best practice
+# but we have to manually enable it. We put it here so npm installs dependencies as the same
+# user who runs the app.
+USER node
 
-# change our working directory to the one we just built.
-WORKDIR /usr/src/app
-COPY . /usr/src/app
+# Copy package over and install it
+COPY package.json package-lock.json* ./
+RUN npm install
+ENV PATH /opt/node_app/node_modules/.bin:$PATH
+
+# copy in our source code
+WORKDIR /opt/node_app/app
+COPY . .
 
 # Expose 3000 for access to our node server
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Feel free to open issues or pull requests. See below for how to get this running
 Mac and Windows' docker installation comes with docker-compose preinstalled. For linux
 Follow the [instructions here](https://docs.docker.com/compose/install/#install-compose).
 
+Make sure to follow the [post-install instructions](https://docs.docker.com/install/linux/linux-postinstall/), too.
+
 ### Booting up your local
 
 Check that your docker and docker-compose are actually installed!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,4 +17,7 @@ services:
     ports:
       - "27017:27017"
     volumes:
-      - ./data:/data/db
+      - mongodata:/data/db
+
+volumes:
+  mongodata: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,10 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./:/usr/src/app
+      - ./:/opt/node_app/app
     links:
       - mongo
-    working_dir: /usr/src/app/
+    working_dir: /opt/node_app/app
     command: 'bash -c "npm start"'
   mongo:
     container_name: mongo

--- a/index.sass
+++ b/index.sass
@@ -1,11 +1,11 @@
-@import './node_modules/bulma/sass/utilities/initial-variables'
-@import './node_modules/bulma/sass/utilities/functions'
+@import '../node_modules/bulma/sass/utilities/initial-variables'
+@import '../node_modules/bulma/sass/utilities/functions'
 // Custom sass for bulma here
 $primary: #26c426
 $info: #ff6600
-@import './node_modules/bulma/bulma.sass'
+@import '../node_modules/bulma/bulma.sass'
 
 a
   color: inherit
-ul 
- list-style-type: none 
+ul
+ list-style-type: none

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "proxy": "http://localhost:4200",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "concurrently \"webpack-dev-server --config  webpack.dev.js --host 0.0.0.0 --inline\" \"nodemon server.js\"",
+    "start": "concurrently \"webpack-dev-server --config  webpack.dev.js --host 0.0.0.0 --inline\" \"supervisor server.js\"",
     "build": "webpack --config webpack.prod.js"
   },
   "env": {
@@ -49,7 +49,6 @@
     "lodash": "^4.17.5",
     "mongoose": "^4.13.11",
     "node-sass": "^4.7.2",
-    "nodemon": "^1.17.1",
     "normalizr": "^3.2.4",
     "react": "^16.8.3",
     "react-burger-menu": "^2.4.2",
@@ -70,6 +69,7 @@
     "redux-thunk": "^2.2.0",
     "sass-loader": "^6.0.7",
     "style-loader": "^0.19.1",
+    "supervisor": "0.12.0",
     "svg-inline-loader": "^0.8.0",
     "uglifyjs-webpack-plugin": "^2.1.2",
     "webpack-hot-middleware": "^2.21.2",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -7,7 +7,7 @@ const common = require('./webpack.common.js');
 module.exports = merge(common, {
   devtool: 'inline-source-map',
   entry: [
-    path.resolve('/usr/src/app/index.js'),
+    path.resolve('/opt/node_app/app/index.js'),
   ],
   output: {
     path: path.resolve(__dirname, 'dist/js/'),


### PR DESCRIPTION
## Motivation
I originally made this dockerization work for node 10 and it also used the local ./node_modules as its source for node packages. Since the node modules were shared between host and docker env, we were having encoding issues with certain libraries. This instead puts the the node modules a directory above the application builds it exclusively for the container.

## Changes
- Cleanup Dockerfile to follow better best practices as given by https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md
- Move node_modules a directory up, don't rely on local's shared node_modules
- Switch from nodemon to petruisfan/node-supervisor because nodemon didn't work for some fucking reason
- Use a named volume to store mongo data so it isn't sitting on your local.